### PR TITLE
Infra - implement scheduled scaling for prod sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@
 ## Links
 1. [Prod site - hello-react-js](https://www.yudimankwanmas.com)
 2. [Prod site - hello-next-js](https://www.yudimankwanmas.com/hello-next-js) 
-3. ~~[Staging site - hello-react-js](https://stg.yudimankwanmas.com)~~ (removed to reduce the maintenance cost)
-4. ~~[Staging site - hello-next-js](https://stg.yudimankwanmas.com/hello-next-js)~~ (removed to reduce the maintenance cost)
-5. [Development site - hello-react-js](https://dev.yudimankwanmas.com)
-6. [Development site - hello-next-js](https://dev.yudimankwanmas.com/hello-next-js) 
+3. [Development site - hello-react-js](https://dev.yudimankwanmas.com)
+4. [Development site - hello-next-js](https://dev.yudimankwanmas.com/hello-next-js) 
+
+## Availability
+| Time (AEST)         | Time (UTC)         | Action     |
+| :------------------ | :----------------: | ---------: |
+| Mon–Fri 9 AM        | Sun–Thu 23:00 UTC  | Scale up   |
+| Mon–Fri 9 PM        | Mon–Fri 11:00 UTC  | Scale down |
+| Sat & Sun All Day   | Sat–Sun            | Scale down |
+
+Scale Down effect: will be served with 503 page
+Scale Up effect: the site is up and running

--- a/README.md
+++ b/README.md
@@ -20,17 +20,23 @@
 [README](https://github.com/hey-you-d/mymonorepo/blob/master/myapps/hello-next-js/README.md)
 
 ## Links
-1. [Prod site - hello-react-js](https://www.yudimankwanmas.com)
-2. [Prod site - hello-next-js](https://www.yudimankwanmas.com/hello-next-js) 
+1. [Production site - hello-react-js](https://www.yudimankwanmas.com)
+2. [Production site - hello-next-js](https://www.yudimankwanmas.com/hello-next-js) 
 3. [Development site - hello-react-js](https://dev.yudimankwanmas.com)
 4. [Development site - hello-next-js](https://dev.yudimankwanmas.com/hello-next-js) 
 
-## Availability
+## Prod Sites Availability
 | Time (AEST)         | Time (UTC)         | Action     |
 | :------------------ | :----------------: | ---------: |
 | Mon–Fri 9 AM        | Sun–Thu 23:00 UTC  | Scale up   |
 | Mon–Fri 9 PM        | Mon–Fri 11:00 UTC  | Scale down |
 | Sat & Sun All Day   | Sat–Sun            | Scale down |
 
-Scale Down effect: will be served with 503 page
-Scale Up effect: the site is up and running
+* Scale Down effect: will be served with 503 page
+* Scale Up effect: the site is up and running
+
+More info: [README](https://github.com/hey-you-d/mymonorepo/blob/dev/copilot/mymonorepo-svc-lb-hello-next-js-trial-1-prod/overrides/README.md)
+
+## Dev Sites Availability
+* All dev sites will be scaled down 24/7. No Load balanced web services will be run when scaled down, hence users will be presented with the 503 "Service not available" page. 
+* This is achieved by running a bash script which will be able to scale up each site on-demand as well. 

--- a/copilot/mymonorepo-svc-lb-hello-next-js-trial-1-prod/overrides/README.md
+++ b/copilot/mymonorepo-svc-lb-hello-next-js-trial-1-prod/overrides/README.md
@@ -24,8 +24,8 @@ Patches are applied in the order specified in the file.
 | Mon–Fri 9 PM        | Mon–Fri 11:00 UTC  | Scale down |
 | Sat & Sun All Day   | Sat–Sun            | Scale down |
 
-Scale Down effect: will be served with 503 page
-Scale Up effect: the site is up and running
+* Scale Down effect: will be served with 503 page
+* Scale Up effect: the site is up and running
 
 ### Explanation:
 As of AWS Copilot v1.34, scheduled scaling is not directly supported within the manifest.yml file.

--- a/copilot/mymonorepo-svc-lb-hello-next-js-trial-1-prod/overrides/README.md
+++ b/copilot/mymonorepo-svc-lb-hello-next-js-trial-1-prod/overrides/README.md
@@ -1,0 +1,43 @@
+# Overriding Copilot generated CloudFormation templates with YAML Patches
+
+The file `cfn.patches.yml` contains a list of YAML/JSON patches to apply to
+your template before AWS Copilot deploys it.
+
+To view examples and an explanation of how YAML patches work, check out the [documentation](https://aws.github.io/copilot-cli/docs/developing/overrides/yamlpatch).
+
+Note only [`add`](https://www.rfc-editor.org/rfc/rfc6902#section-4.1),
+[`remove`](https://www.rfc-editor.org/rfc/rfc6902#section-4.2), and
+[`replace`](https://www.rfc-editor.org/rfc/rfc6902#section-4.3)
+operations are supported by Copilot.
+Patches are applied in the order specified in the file.
+
+## Troubleshooting
+
+* `copilot [noun] package` preview the transformed template by writing to stdout.
+* `copilot [noun] package --diff` show the difference against the template deployed in your environment.
+
+## New Schedule
+
+| Time (AEST)         | Time (UTC)         | Action     |
+| :------------------ | :----------------: | ---------: |
+| Mon–Fri 9 AM        | Sun–Thu 23:00 UTC  | Scale up   |
+| Mon–Fri 9 PM        | Mon–Fri 11:00 UTC  | Scale down |
+| Sat & Sun All Day   | Sat–Sun            | Scale down |
+
+Scale Down effect: will be served with 503 page
+Scale Up effect: the site is up and running
+
+### Explanation:
+As of AWS Copilot v1.34, scheduled scaling is not directly supported within the manifest.yml file.
+
+To implement scheduled scaling, I'm utilizing AWS Copilot's support for CloudFormation overrides. By creating an addons.yml file, I can define scheduled scaling actions using AWS Application Auto Scaling resources. This approach allows specifying scaling policies that adjust the desired count of your ECS services at scheduled times.
+
+```bash
+copilot svc override --env production
+```
+
+to deploy the service with scheduling overrides:
+
+```bash
+copilot svc deploy --name your-service-name --env production
+```

--- a/copilot/mymonorepo-svc-lb-hello-next-js-trial-1-prod/overrides/cfn.patches.yml
+++ b/copilot/mymonorepo-svc-lb-hello-next-js-trial-1-prod/overrides/cfn.patches.yml
@@ -1,0 +1,52 @@
+# Delete the task role resource
+# - op: remove
+#   path: /Resources/TaskRole
+
+# Add a service connect alias
+# - op: add
+#   path: /Resources/Service/Properties/ServiceConnectConfiguration/Services/0/ClientAliases/-
+#   value:
+#     Port: !Ref TargetPort
+#     DnsName: yamlpatchiscool
+
+# Replace the task role in the task definition
+# - op: replace
+#   path: /Resources/TaskDefinition/Properties/TaskRoleArn
+#   value: arn:aws:iam::123456789012:role/MyTaskRole
+
+Resources:
+  ScheduledScaleDownNight:
+    Type: AWS::ApplicationAutoScaling::ScheduledAction
+    Properties:
+      ScheduledActionName: ScaleDownWeeknights
+      ServiceNamespace: ecs
+      ResourceId: !Sub "service/mymonorepo-app-trial-1-production-Cluster-8aYgoWUVqGeI/mymonorepo-app-trial-1-production-mymonorepo-svc-lb-hello-next-js-trial-1-prod-Service-EAsQ9ulL2MMR"
+      ScalableDimension: ecs:service:DesiredCount
+      Schedule: "cron(0 11 ? * MON-FRI *)"
+      ScalableTargetAction:
+        MinCapacity: 0
+        MaxCapacity: 0
+
+  ScheduledScaleDownWeekend:
+    Type: AWS::ApplicationAutoScaling::ScheduledAction
+    Properties:
+      ScheduledActionName: ScaleDownWeekend
+      ServiceNamespace: ecs
+      ResourceId: !Sub "service/mymonorepo-app-trial-1-production-Cluster-8aYgoWUVqGeI/mymonorepo-app-trial-1-production-mymonorepo-svc-lb-hello-next-js-trial-1-prod-Service-EAsQ9ulL2MMR"
+      ScalableDimension: ecs:service:DesiredCount
+      Schedule: "cron(0 0 ? * SAT,SUN *)"
+      ScalableTargetAction:
+        MinCapacity: 0
+        MaxCapacity: 0
+
+  ScheduledScaleUpWeekdays:
+    Type: AWS::ApplicationAutoScaling::ScheduledAction
+    Properties:
+      ScheduledActionName: ScaleUpWeekdays
+      ServiceNamespace: ecs
+      ResourceId: !Sub "service/mymonorepo-app-trial-1-production-Cluster-8aYgoWUVqGeI/mymonorepo-app-trial-1-production-mymonorepo-svc-lb-hello-next-js-trial-1-prod-Service-EAsQ9ulL2MMR"
+      ScalableDimension: ecs:service:DesiredCount
+      Schedule: "cron(0 23 ? * SUN-THU *)"
+      ScalableTargetAction:
+        MinCapacity: 1
+        MaxCapacity: 1

--- a/copilot/mymonorepo-svc-lb-trial-1-prod/overrides/README.md
+++ b/copilot/mymonorepo-svc-lb-trial-1-prod/overrides/README.md
@@ -24,8 +24,8 @@ Patches are applied in the order specified in the file.
 | Mon–Fri 9 PM        | Mon–Fri 11:00 UTC  | Scale down |
 | Sat & Sun All Day   | Sat–Sun            | Scale down |
 
-Scale Down effect: will be served with 503 page
-Scale Up effect: the site is up and running
+* Scale Down effect: will be served with 503 page
+* Scale Up effect: the site is up and running
 
 ### Explanation:
 As of AWS Copilot v1.34, scheduled scaling is not directly supported within the manifest.yml file.

--- a/copilot/mymonorepo-svc-lb-trial-1-prod/overrides/README.md
+++ b/copilot/mymonorepo-svc-lb-trial-1-prod/overrides/README.md
@@ -1,0 +1,43 @@
+# Overriding Copilot generated CloudFormation templates with YAML Patches
+
+The file `cfn.patches.yml` contains a list of YAML/JSON patches to apply to
+your template before AWS Copilot deploys it.
+
+To view examples and an explanation of how YAML patches work, check out the [documentation](https://aws.github.io/copilot-cli/docs/developing/overrides/yamlpatch).
+
+Note only [`add`](https://www.rfc-editor.org/rfc/rfc6902#section-4.1),
+[`remove`](https://www.rfc-editor.org/rfc/rfc6902#section-4.2), and
+[`replace`](https://www.rfc-editor.org/rfc/rfc6902#section-4.3)
+operations are supported by Copilot.
+Patches are applied in the order specified in the file.
+
+## Troubleshooting
+
+* `copilot [noun] package` preview the transformed template by writing to stdout.
+* `copilot [noun] package --diff` show the difference against the template deployed in your environment.
+
+## New Schedule
+
+| Time (AEST)         | Time (UTC)         | Action     |
+| :------------------ | :----------------: | ---------: |
+| Mon–Fri 9 AM        | Sun–Thu 23:00 UTC  | Scale up   |
+| Mon–Fri 9 PM        | Mon–Fri 11:00 UTC  | Scale down |
+| Sat & Sun All Day   | Sat–Sun            | Scale down |
+
+Scale Down effect: will be served with 503 page
+Scale Up effect: the site is up and running
+
+### Explanation:
+As of AWS Copilot v1.34, scheduled scaling is not directly supported within the manifest.yml file.
+
+To implement scheduled scaling, I'm utilizing AWS Copilot's support for CloudFormation overrides. By creating an addons.yml file, I can define scheduled scaling actions using AWS Application Auto Scaling resources. This approach allows specifying scaling policies that adjust the desired count of your ECS services at scheduled times.
+
+```bash
+copilot svc override --env production
+```
+
+to deploy the service with scheduling overrides:
+
+```bash
+copilot svc deploy --name your-service-name --env production
+```

--- a/copilot/mymonorepo-svc-lb-trial-1-prod/overrides/cfn.patches.yml
+++ b/copilot/mymonorepo-svc-lb-trial-1-prod/overrides/cfn.patches.yml
@@ -1,0 +1,52 @@
+# Delete the task role resource
+# - op: remove
+#   path: /Resources/TaskRole
+
+# Add a service connect alias
+# - op: add
+#   path: /Resources/Service/Properties/ServiceConnectConfiguration/Services/0/ClientAliases/-
+#   value:
+#     Port: !Ref TargetPort
+#     DnsName: yamlpatchiscool
+
+# Replace the task role in the task definition
+# - op: replace
+#   path: /Resources/TaskDefinition/Properties/TaskRoleArn
+#   value: arn:aws:iam::123456789012:role/MyTaskRole
+
+Resources:
+  ScheduledScaleDownNight:
+    Type: AWS::ApplicationAutoScaling::ScheduledAction
+    Properties:
+      ScheduledActionName: ScaleDownWeeknights
+      ServiceNamespace: ecs
+      ResourceId: !Sub "service/mymonorepo-app-trial-1-production-Cluster-8aYgoWUVqGeI/mymonorepo-app-trial-1-production-mymonorepo-svc-lb-trial-1-Service-OV052RhfBcZ6"
+      ScalableDimension: ecs:service:DesiredCount
+      Schedule: "cron(0 11 ? * MON-FRI *)"
+      ScalableTargetAction:
+        MinCapacity: 0
+        MaxCapacity: 0
+
+  ScheduledScaleDownWeekend:
+    Type: AWS::ApplicationAutoScaling::ScheduledAction
+    Properties:
+      ScheduledActionName: ScaleDownWeekend
+      ServiceNamespace: ecs
+      ResourceId: !Sub "service/mymonorepo-app-trial-1-production-Cluster-8aYgoWUVqGeI/mymonorepo-app-trial-1-production-mymonorepo-svc-lb-trial-1-Service-OV052RhfBcZ6"
+      ScalableDimension: ecs:service:DesiredCount
+      Schedule: "cron(0 0 ? * SAT,SUN *)"
+      ScalableTargetAction:
+        MinCapacity: 0
+        MaxCapacity: 0
+
+  ScheduledScaleUpWeekdays:
+    Type: AWS::ApplicationAutoScaling::ScheduledAction
+    Properties:
+      ScheduledActionName: ScaleUpWeekdays
+      ServiceNamespace: ecs
+      ResourceId: !Sub "service/mymonorepo-app-trial-1-production-Cluster-8aYgoWUVqGeI/mymonorepo-app-trial-1-production-mymonorepo-svc-lb-trial-1-Service-OV052RhfBcZ6"
+      ScalableDimension: ecs:service:DesiredCount
+      Schedule: "cron(0 23 ? * SUN-THU *)"
+      ScalableTargetAction:
+        MinCapacity: 1
+        MaxCapacity: 1


### PR DESCRIPTION
with Copilot support for CloudFormation overrides

--- For dev sites:
manually scale down with bash scripts, hence all dev sites will always serve 503 unless manually scale-up the ALB via the script (on-demand scale-up)