### PR TITLE
hello-next-js - feat: TASK CRUD - modify check auth_token logic 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@
 3. Demonstrate knowledge of various Frontend features such as:
     - data querying with graphQL, **-- STATUS: FULFILLED**
     - basic user registration/login, **-- STATUS: FULFILLED**
-    - authentication & authorization with JWT **-- STATUS: FULFILLED**
-    - authentication & authorization with JWT + refresh token **-- STATUS: TODO**
-    - authentication & authorization with JWT + OAUTH 2.0 & OIDC via Auth0 identity service, **-- STATUS: TODO** 
+    - authentication & authorization with JWT (sans refresh token implementation) **-- STATUS: FULFILLED**
+    - authentication & authorization with JWT + OAUTH 2.0 & OIDC via Auth0 identity service (access token & refresh token implementation), **-- STATUS: TODO** 
     - client-side caching with Vercel SWR, **-- STATUS: FULFILLED**
     - unit testing with Jest, **-- STATUS: FULFILLED**
     - styling with Tailwind CSS, **-- STATUS: TODO**

--- a/myapps/hello-next-js/README.md
+++ b/myapps/hello-next-js/README.md
@@ -90,10 +90,9 @@ yarn workspace hello-next-js start
         - MVVM - view component #2: [taskDetailPage.tsx](https://github.com/hey-you-d/mymonorepo/blob/master/myapps/hello-next-js/src/views/Task/use-server/taskDetailPage.tsx)
         - Next.js App router: [/task-crud-fullstack/use-server/page.tsx](https://github.com/hey-you-d/mymonorepo/tree/master/myapps/hello-next-js/src/app/task-crud-fullstack/use-server/page.tsx)
         - Next.js App router #2: [/task-crud-fullstack/use-server/edit/[id]](https://github.com/hey-you-d/mymonorepo/tree/master/myapps/hello-next-js/src/app/task-crud-fullstack/use-server/edit/[id]/page.tsx)    
-4. Authentication & Authorization with Basic Auth & JWT  
+4. Authentication & Authorization with Basic Auth & JWT (No refresh token implementation) 
     - [API Authorization with JWT (bearer token in Authorization header)] **STATUS: DONE** 
-        - [Merged PR](https://github.com/hey-you-d/mymonorepo/pull/83) 
-    - [Refresh Token implementation] **STATUS: IN PROGRESS**    
+        - [Merged PR](https://github.com/hey-you-d/mymonorepo/pull/83)    
     - [API endpoint] **STATUS: DONE**
         - [user API endpoint](https://github.com/hey-you-d/mymonorepo/tree/master/myapps/hello-next-js/pages/api/tasks/v1/sql/user)
     - [Client-side components variant - React.js components which are rendered via Next.js Page router] 
@@ -110,7 +109,7 @@ yarn workspace hello-next-js start
             - Model component: [TaskUserGraphqlClient.ts](https://github.com/hey-you-d/mymonorepo/blob/master/myapps/hello-next-js/src/models/Task/use-server/TaskUserGraphqlClient.ts)
             - ViewModel component: [getTasksUserGraphQLViewModel.ts](https://github.com/hey-you-d/mymonorepo/blob/master/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserGraphQLViewModel.ts)
             - View component: [taskUserGraphQL.tsx](https://github.com/hey-you-d/mymonorepo/blob/master/myapps/hello-next-js/src/views/Task/use-server/taskUserGraphQL.tsx)       
-5. Authentication & Authorization with OAUTH 2.0 & OIDC via AUTH0 Identity Service - **STATUS: TODO**
+5. Authentication & Authorization with OAUTH 2.0 & OIDC via AUTH0 Identity Service (Access Token & Refresh Token implementation) - **STATUS: TODO**
 6. Frontend feature [Client-side components variant only]: Client-side Caching implementation with Vercel SWR  
     - [Client-side components variant - React.js components which are rendered via Next.js Page router] **STATUS: DONE**
         - Localhost URL: [localhost:3000/hello-next-js/task-crud-fullstack/with-swr](http://localhost:3000/hello-next-js/task-crud-fullstack/with-swr)  

--- a/myapps/hello-next-js/pages/api/tasks/v1/bff/user/httpcookie.ts
+++ b/myapps/hello-next-js/pages/api/tasks/v1/bff/user/httpcookie.ts
@@ -1,11 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { JWT_TOKEN_COOKIE_NAME } from "@/lib/app/common";
 import * as cookie from 'cookie';
+import { VERIFY_JWT_STRING, verifyJwtErrorMsgs } from '@/lib/app/common';
 
 // for reference:
 // for SPA: rely on BFF (the approach below) for any server-side operations
 // for next.js pages: better use Page router's getServerSideProps or App router's server actions  
-const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     switch (req.method) {
         case "GET" :
             try {
@@ -20,9 +21,22 @@ const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void>
 
                 // if token is either undefined or its value is an empty string, 
                 // then it's no longer exist in the client browser
-                return res.status(200).json({  outcome: token && token.length > 0 })    
+
+                // check if token has already expired or not
+                if (token && token.length > 0) {
+                    const result = await VERIFY_JWT_STRING(token);
+                    console.log("BFF httpCookie ", result);
+
+                    return res.status(200).json({  
+                        outcome: result.valid, 
+                        message: result.valid ? result.payload : result.error, 
+                    });
+                }
+                
+                return res.status(500).json({  outcome: false, message: "User BFF - check auth_token cookie - unknown server error" });    
             } catch (error) {
-                console.error("User BFF - check auth_token cookie - Error: checking http-only cookie wasn't successful : ", error);
+                
+                console.error("User BFF - check auth_token cookie - Error: unsuccessfully checking http-only cookie : ", error);
         
                 throw error;
             }

--- a/myapps/hello-next-js/pages/api/tasks/v1/bff/user/httpcookie.ts
+++ b/myapps/hello-next-js/pages/api/tasks/v1/bff/user/httpcookie.ts
@@ -26,7 +26,6 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
                 // check if token has already expired or not
                 if (token && token.length > 0) {
                     const result = await VERIFY_JWT_STRING(token);
-                    console.log("BFF httpCookie ", result);
 
                     // if the token is already expired, set the cookie value to an empty string, therefore invalidating it
                     if(!result.valid && result.error === verifyJwtErrorMsgs.TokenExpiredError) {

--- a/myapps/hello-next-js/pages/api/tasks/v1/bff/user/httpcookie.ts
+++ b/myapps/hello-next-js/pages/api/tasks/v1/bff/user/httpcookie.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { JWT_TOKEN_COOKIE_NAME } from "@/lib/app/common";
 import * as cookie from 'cookie';
-import { VERIFY_JWT_STRING, verifyJwtErrorMsgs } from '@/lib/app/common';
+import { VERIFY_JWT_STRING } from '@/lib/app/common';
 
 // for reference:
 // for SPA: rely on BFF (the approach below) for any server-side operations

--- a/myapps/hello-next-js/pages/api/tasks/v1/bff/user/logout.ts
+++ b/myapps/hello-next-js/pages/api/tasks/v1/bff/user/logout.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { JWT_TOKEN_COOKIE_NAME } from "@/lib/app/common";
+import { serialize } from 'cookie';
+import { APP_ENV, LIVE_SITE_MODE, LOCALHOST_MODE } from "@/lib/app/featureFlags";
 
 // for reference:
 // for SPA: rely on BFF (the approach below) for any server-side operations
@@ -8,8 +10,28 @@ const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void>
     switch (req.method) {
         case "GET" :
             try {
+                // for reference: you can't actually delete a cookie, you can only:
+                // Set its value to empty (or null), & Set Max-Age=0 or Expires=<past date>,
+
                 // Invalidate cookie by setting it to empty with maxAge = 0
-                res.setHeader('Set-Cookie', `${JWT_TOKEN_COOKIE_NAME}=; Path=/; HttpOnly; Max-Age=0; SameSite=Strict`);
+                //res.setHeader('Set-Cookie', `${JWT_TOKEN_COOKIE_NAME}=; Path=/; HttpOnly; Max-Age=0; SameSite=Strict`);
+                const path = APP_ENV == "LIVE" 
+                        ? LIVE_SITE_MODE.cookie.path 
+                        : LOCALHOST_MODE.cookie.path;
+                    const secure = APP_ENV == "LIVE" 
+                        ? LIVE_SITE_MODE.cookie.secure
+                        : LOCALHOST_MODE.cookie.secure;
+                
+                // for reference: cookie.serialize() ensures safe encoding and formatting, avoiding issues with special characters.        
+                const cookieStr = serialize(JWT_TOKEN_COOKIE_NAME, '', {
+                    httpOnly: true,
+                    secure,
+                    path,
+                    sameSite: 'strict',
+                    maxAge: 0, // expire immediately
+                });
+
+                res.setHeader('Set-Cookie', cookieStr);
                 
                 // let client verify if the cookie has been deleted in a subsequent request
                 return res.status(200).json({ 

--- a/myapps/hello-next-js/pages/api/tasks/v1/bff/user/register.ts
+++ b/myapps/hello-next-js/pages/api/tasks/v1/bff/user/register.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import argon2 from 'argon2';
 import { sign } from 'jsonwebtoken';
+import { serialize } from 'cookie';
 import type { UserModelType } from '@/types/Task';
 import { 
     JWT_TOKEN_COOKIE_NAME, 
@@ -11,13 +12,7 @@ import { APP_ENV, LOCALHOST_MODE, LIVE_SITE_MODE } from '@/lib/app/featureFlags'
 import { getJwtSecret } from '@/lib/app/common';
 
 export const createAuthCookie = async (res: NextApiResponse, jwt: string) => {
-    const path = APP_ENV == "LIVE" 
-        ? LIVE_SITE_MODE.cookie.path 
-        : LOCALHOST_MODE.cookie.path;
-    const secure = APP_ENV == "LIVE" 
-        ? LIVE_SITE_MODE.cookie.secure
-        : LOCALHOST_MODE.cookie.secure;
-
+    /*
     const cookieParts = [
         `${JWT_TOKEN_COOKIE_NAME}=${jwt}`,
         `Path=${path}`,
@@ -28,6 +23,24 @@ export const createAuthCookie = async (res: NextApiResponse, jwt: string) => {
     if (secure) cookieParts.push('Secure'); // Append 'Secure' only if true
 
     res.setHeader('Set-Cookie', cookieParts.join('; '));
+    */
+    const path = APP_ENV == "LIVE" 
+        ? LIVE_SITE_MODE.cookie.path 
+        : LOCALHOST_MODE.cookie.path;
+    const secure = APP_ENV == "LIVE" 
+        ? LIVE_SITE_MODE.cookie.secure
+        : LOCALHOST_MODE.cookie.secure;
+
+    const cookieStr = serialize(JWT_TOKEN_COOKIE_NAME, '', {
+        httpOnly: true,
+        secure,
+        path,
+        sameSite: 'strict',
+        maxAge: 3600, // 1hr
+    });
+
+    res.setHeader('Set-Cookie', cookieStr);
+    
 }
 
 export const generateHashedPassword = async (password: string) => {

--- a/myapps/hello-next-js/pages/api/tasks/v1/bff/user/register.ts
+++ b/myapps/hello-next-js/pages/api/tasks/v1/bff/user/register.ts
@@ -47,7 +47,7 @@ export const generateJWT = async (email: string, hashedPwd: string, jwtSecret: s
     return await sign(
         { email, hashedPassword: hashedPwd  },
         jwtSecret,
-        { expiresIn: '1h' }
+        { expiresIn: '900000' } // 90000ms = 15mins
     );
 }
 

--- a/myapps/hello-next-js/pages/api/tasks/v1/bff/user/register.ts
+++ b/myapps/hello-next-js/pages/api/tasks/v1/bff/user/register.ts
@@ -31,7 +31,7 @@ export const createAuthCookie = async (res: NextApiResponse, jwt: string) => {
         ? LIVE_SITE_MODE.cookie.secure
         : LOCALHOST_MODE.cookie.secure;
 
-    const cookieStr = serialize(JWT_TOKEN_COOKIE_NAME, '', {
+    const cookieStr = serialize(JWT_TOKEN_COOKIE_NAME, jwt, {
         httpOnly: true,
         secure,
         path,
@@ -40,7 +40,6 @@ export const createAuthCookie = async (res: NextApiResponse, jwt: string) => {
     });
 
     res.setHeader('Set-Cookie', cookieStr);
-    
 }
 
 export const generateHashedPassword = async (password: string) => {

--- a/myapps/hello-next-js/src/lib/app/common.ts
+++ b/myapps/hello-next-js/src/lib/app/common.ts
@@ -81,7 +81,7 @@ export const generateJWT = async (email: string, hashedPwd: string, jwtSecret: s
     return await sign(
         { email, hashedPassword: hashedPwd  },
         jwtSecret,
-        { expiresIn: '1h' }
+        { expiresIn: '900000' } // 90000ms = 15mins
     );
 }
 

--- a/myapps/hello-next-js/src/models/Task/use-client/TaskUserModel.test.ts
+++ b/myapps/hello-next-js/src/models/Task/use-client/TaskUserModel.test.ts
@@ -236,7 +236,7 @@ describe('TaskUserModel', () => {
                     credentials: 'include',
                 }
             );
-            expect(result).toBe(true);
+            expect(result).toStrictEqual({ outcome: true });
         });
         it('should return false when auth token cookie does not exist', async () => {
             mockFetch.mockResolvedValueOnce({
@@ -246,7 +246,7 @@ describe('TaskUserModel', () => {
 
             const result = await taskUserModel.checkAuthTokenCookieExist();
 
-            expect(result).toBe(false);
+            expect(result).toStrictEqual({ outcome: false });
         });
         it('should work with override URL', async () => {
             const overrideUrl = 'http://custom-url.com/api';
@@ -261,7 +261,7 @@ describe('TaskUserModel', () => {
                 `${overrideUrl}/user/httpcookie`,
                 expect.any(Object)
             );
-            expect(result).toBe(true);
+            expect(result).toStrictEqual({ outcome: true });
         });
         it('should throw error when cookie check fails', async () => {
             const errorResponse = {
@@ -277,8 +277,7 @@ describe('TaskUserModel', () => {
             ).rejects.toThrow('TaskUserModel - Error check auth_token cookie attempt: 403');
 
             expect(console.error).toHaveBeenCalledWith(
-                'TaskUserModel - Error check auth_token cookie attempt: 403 - Forbidden',
-                'Access denied'
+                'TaskUserModel - Error check auth_token cookie attempt: 403 - Forbidden - Access denied'
             );
         });
     });

--- a/myapps/hello-next-js/src/models/Task/use-client/TaskUserModel.ts
+++ b/myapps/hello-next-js/src/models/Task/use-client/TaskUserModel.ts
@@ -83,7 +83,7 @@ export class TaskUserModel {
         return result;
     }
 
-    async checkAuthTokenCookieExist(overrideFetchUrl?: string): Promise<boolean> {
+    async checkAuthTokenCookieExist(overrideFetchUrl?: string): Promise<{ outcome: boolean, message: string }> {
         // In case this fn is called from within Next.js page routes methods such as getServerSideProps.
         // In this case, we must supply an absolute URL  
         const finalUrl = overrideFetchUrl ? overrideFetchUrl : `${TASKS_BFF_BASE_API_URL}`;
@@ -96,12 +96,13 @@ export class TaskUserModel {
 
         if (!response.ok) {
             const errorText = await response.text();
-            console.error(`TaskUserModel - Error check auth_token cookie attempt: ${response.status} - ${response.statusText}`, errorText);
-            throw new Error(`TaskUserModel - Error check auth_token cookie attempt: ${response.status}`);
+            const errMessage = `TaskUserModel - Error check auth_token cookie attempt: ${response.status} - ${response.statusText} - ${errorText}`; 
+            console.error(errMessage);
+            throw new Error(errMessage);
         }
 
-        const result: { outcome: boolean } = await response.json();
+        const result: { outcome: boolean, message: string } = await response.json();
         
-        return result.outcome;
+        return result;
     }
 }

--- a/myapps/hello-next-js/src/viewModels/Task/use-client/useTaskUserViewModel.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-client/useTaskUserViewModel.ts
@@ -59,7 +59,7 @@ const useTaskUserViewModel = () => {
     const checkAuthTokenCookieExist = useCallback(async () => {
         setLoading(true);
         try {
-          const result: boolean = await taskUserModel.checkAuthTokenCookieExist();
+          const result: { outcome: boolean, message: string } = await taskUserModel.checkAuthTokenCookieExist();
           return result;
         } catch (error) {
           console.error("useTaskUserViewModel | checkAuthTokenCookieExist | Error: check http-only auth_token cookie failure: ", error);

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.test.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.test.ts
@@ -215,7 +215,7 @@ describe("getTasksUserViewModel", () => {
         expect(sign).toHaveBeenCalledWith(
             { email, hashedPassword: hashedPwd },
             jwtSecret,
-            { expiresIn: '1h' }
+            { expiresIn: '900000' } // 90000sec = 15mins
         );
         expect(result).toBe(expectedToken);
         });

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.test.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.test.ts
@@ -93,6 +93,9 @@ describe("getTasksUserViewModel", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+
+        // hide console.error to reduce noise on the console output
+        spyConsoleError = jest.spyOn(console, "error").mockImplementation(()=> {});
         
         // Setup mock cookie store
         mockCookieStore = {

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
@@ -195,7 +195,6 @@ export const checkAuthTokenCookieExist = async () => {
         // check if token has already expired or not
         if (token && token.value.length > 0) {
             const result = await VERIFY_JWT_STRING(token.value);
-            console.log("use-server | getTasksUserViewModel ", result);
 
             // delete the cookie if the token is already expired
             if (!result.valid && result.error === verifyJwtErrorMsgs.TokenExpiredError) {

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
@@ -51,7 +51,7 @@ export const createAuthCookie = async (jwt: string) => {
             ? LIVE_SITE_MODE.cookie.secure
             : LOCALHOST_MODE.cookie.secure, // set to true to travel over HTTPS
         sameSite: 'strict', // set to strict to prevent CSRF attack
-        maxAge: 3600, // lets keep token expiration short (1hr or less for access token)
+        maxAge: 15, // lets keep token expiration short (1hr or less for access token)
         path: APP_ENV == "LIVE" 
             ? LIVE_SITE_MODE.cookie.path 
             : LOCALHOST_MODE.cookie.path, // limit cookie accessibility
@@ -79,7 +79,7 @@ export const generateJWT = async (email: string, hashedPwd: string, jwtSecret: s
     return await sign(
         { email, hashedPassword: hashedPwd  },
         jwtSecret,
-        { expiresIn: '1h' }
+        { expiresIn: '900000' } // 90000ms = 15mins
     );
 }
 
@@ -191,10 +191,25 @@ export const checkAuthTokenCookieExist = async () => {
     try {
         const cookieStore = await cookies();
         const token = cookieStore.get(JWT_TOKEN_COOKIE_NAME);
+        
+        // check if token has already expired or not
+        if (token && token.value.length > 0) {
+            const result = await VERIFY_JWT_STRING(token.value);
+            console.log("use-server | getTasksUserViewModel ", result);
 
-        return token && token.value.length > 0;
+            return ({  
+                outcome: result.valid, 
+                message: result.valid ? result.payload : result.error, 
+            });
+        }
+        
+        return ({  
+            outcome: false, 
+            message: `use-server | getTasksUserViewModel | Unknown Error when checking auth_token`, 
+        });
     } catch (error) {
-        console.error(`user-server | getTasksUserViewModel | Unknown Error when checking auth_token: ${(error as Error).name} - ${(error as Error).message}`);
-        throw new Error(`user-server | getTasksUserViewModel | Unknown Error when checking auth_token: ${(error as Error).name} - ${(error as Error).message}`);
+        const errorMessage = `use-server | getTasksUserViewModel | Unknown Error when checking auth_token: ${(error as Error).name} - ${(error as Error).message}`;
+        console.error(errorMessage);
+        throw new Error(errorMessage);
     }
 }

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
@@ -51,7 +51,7 @@ export const createAuthCookie = async (jwt: string) => {
             ? LIVE_SITE_MODE.cookie.secure
             : LOCALHOST_MODE.cookie.secure, // set to true to travel over HTTPS
         sameSite: 'strict', // set to strict to prevent CSRF attack
-        maxAge: 15, // lets keep token expiration short (1hr or less for access token)
+        maxAge: 3600, // lets keep token expiration short (1hr or less for access token)
         path: APP_ENV == "LIVE" 
             ? LIVE_SITE_MODE.cookie.path 
             : LOCALHOST_MODE.cookie.path, // limit cookie accessibility

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
@@ -197,6 +197,11 @@ export const checkAuthTokenCookieExist = async () => {
             const result = await VERIFY_JWT_STRING(token.value);
             console.log("use-server | getTasksUserViewModel ", result);
 
+            // delete the cookie if the token is already expired
+            if (!result.valid && result.error === verifyJwtErrorMsgs.TokenExpiredError) {
+                cookieStore.delete(JWT_TOKEN_COOKIE_NAME);
+            }
+
             return ({  
                 outcome: result.valid, 
                 message: result.valid ? result.payload : result.error, 

--- a/myapps/hello-next-js/src/views/Task/use-client/taskDetailPage.test.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-client/taskDetailPage.test.tsx
@@ -50,7 +50,7 @@ describe('TaskDetailPage', () => {
     ];
 
     const mockDeleteRowFromId = jest.fn();
-    const mockCheckAuthTokenCookieExist = jest.fn();
+    const mockCheckAuthTokenCookieExist = jest.fn().mockResolvedValue({ outcome: true });
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -93,7 +93,7 @@ describe('TaskDetailPage', () => {
 
     describe('Authentication flow', () => {
         it('should check authentication on mount', async () => {
-            mockCheckAuthTokenCookieExist.mockResolvedValue(true);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: true });
 
             render(<TaskDetailPage id={1} />);
 
@@ -103,7 +103,7 @@ describe('TaskDetailPage', () => {
         });
 
         it('should show TaskDetail when user is authenticated and task exists', async () => {
-            mockCheckAuthTokenCookieExist.mockResolvedValue(true);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: true });
 
             render(<TaskDetailPage id={1} />);
 
@@ -115,7 +115,7 @@ describe('TaskDetailPage', () => {
         });
 
         it('should show login message when user is not authenticated', async () => {
-            mockCheckAuthTokenCookieExist.mockResolvedValue(false);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: false });
 
             render(<TaskDetailPage id={1} />);
 
@@ -129,7 +129,7 @@ describe('TaskDetailPage', () => {
 
     describe('Task existence', () => {
         it('should show task not found message when task does not exist but user is authenticated', async () => {
-            mockCheckAuthTokenCookieExist.mockResolvedValue(true);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: true });
 
             render(<TaskDetailPage id={999} />); // Non-existent task ID
 
@@ -141,7 +141,7 @@ describe('TaskDetailPage', () => {
         });
 
         it('should find and display the correct task by id', async () => {
-            mockCheckAuthTokenCookieExist.mockResolvedValue(true);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: true });
 
             render(<TaskDetailPage id={2} />);
 
@@ -154,7 +154,7 @@ describe('TaskDetailPage', () => {
 
     describe('Navigation', () => {
         it('should always render back link to tasks page', async () => {
-            mockCheckAuthTokenCookieExist.mockResolvedValue(true);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: true });
 
             render(<TaskDetailPage id={1} />);
 
@@ -166,7 +166,7 @@ describe('TaskDetailPage', () => {
         });
 
         it('should render back link even when not authenticated', async () => {
-            mockCheckAuthTokenCookieExist.mockResolvedValue(false);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: false });
 
             render(<TaskDetailPage id={1} />);
 
@@ -180,7 +180,7 @@ describe('TaskDetailPage', () => {
 
     describe('Props handling', () => {
         it('should pass correct props to TaskDetail component', async () => {
-            mockCheckAuthTokenCookieExist.mockResolvedValue(true);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: true });
 
             render(<TaskDetailPage id={1} />);
 
@@ -198,6 +198,7 @@ describe('TaskDetailPage', () => {
 
     describe('State management', () => {
         it('should update authentication state when token status changes', async () => {
+            // manual Promise control to simulate delayed auth resolution
             let resolveAuthCheck: (value: unknown) => void = (x) => {};
             const authPromise = new Promise(resolve => {
                 resolveAuthCheck = resolve;
@@ -211,7 +212,7 @@ describe('TaskDetailPage', () => {
             expect(screen.getByText('You must be logged-in first to edit this task')).toBeInTheDocument();
 
             // Resolve auth check as authenticated
-            resolveAuthCheck(true);
+            resolveAuthCheck({ outcome: true });
 
             await waitFor(() => {
                 expect(screen.queryByText('You must be logged-in first to edit this task')).not.toBeInTheDocument();
@@ -228,7 +229,7 @@ describe('TaskDetailPage', () => {
                 deleteRowFromId: mockDeleteRowFromId
             });
             
-            mockCheckAuthTokenCookieExist.mockResolvedValue(true);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: true });
 
             render(<TaskDetailPage id={1} />);
 

--- a/myapps/hello-next-js/src/views/Task/use-client/taskDetailPage.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-client/taskDetailPage.tsx
@@ -11,7 +11,7 @@ import { MONOREPO_PREFIX, TASKS_CRUD } from '@/lib/app/common';
 export const TaskDetailPage = ({id}: {id: number}) => {
   //const { tasks, loading, deleteRowFromId } = useTaskViewModel();
   const { tasks, loading, deleteRowFromId } = useTaskViewModelWithSwr();
-  const { checkAuthTokenCookieExist } = useTaskUserViewModel();
+  const { checkAuthTokenCookieExist, logoutUser } = useTaskUserViewModel();
 
   const [row, setRow] = useState<Task | undefined>(undefined);
   const [buttonDisabled, setButtonDisabled] = useState<boolean>(false);
@@ -29,12 +29,13 @@ export const TaskDetailPage = ({id}: {id: number}) => {
             // for reference: the http only auth_token cookie is not accessible from the client-side
             try {
               const authTokenCookieExist = await checkAuthTokenCookieExist();
-              if (authTokenCookieExist && !userAuthenticated) {
+              if (authTokenCookieExist.outcome && !userAuthenticated) {
                   setUserAuthenticated(true);
               }
-              if (!authTokenCookieExist && userAuthenticated) {
+              if (!authTokenCookieExist.outcome && userAuthenticated) {
+                  await logoutUser();
                   setUserAuthenticated(false);
-    
+                  
                   // TODO: a modal popup that says "you have been logged out"
               }
             } catch(err) {

--- a/myapps/hello-next-js/src/views/Task/use-client/taskDetailPage.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-client/taskDetailPage.tsx
@@ -46,7 +46,7 @@ export const TaskDetailPage = ({id}: {id: number}) => {
         };
   
         checkUserLoggedIn();
-    }, [setUserAuthenticated, userAuthenticated, checkAuthTokenCookieExist]);
+    }, [setUserAuthenticated, userAuthenticated, checkAuthTokenCookieExist, logoutUser]);
   
 
   if (loading) return <p>Loading...</p>;

--- a/myapps/hello-next-js/src/views/Task/use-client/taskUser.test.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-client/taskUser.test.tsx
@@ -57,6 +57,7 @@ describe('TaskUser Component (client-side variant)', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         (useTaskUserViewModel as jest.Mock).mockReturnValue(mockViewModel);
+        mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: true }); 
         mockSessionStorage.getItem.mockReturnValue(null);
         // hide console.error to reduce noise on the console output
         spyConsoleError = jest.spyOn(console, "error").mockImplementation(()=> {});
@@ -98,7 +99,7 @@ describe('TaskUser Component (client-side variant)', () => {
         });
 
         it('checks auth token cookie on mount', async () => {
-            mockCheckAuthTokenCookieExist.mockResolvedValue(true);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: true });
             
             render(<TaskUser {...defaultProps} />);
 
@@ -109,7 +110,7 @@ describe('TaskUser Component (client-side variant)', () => {
         });
 
         it('sets user as unauthenticated when no auth token cookie exists', async () => {
-            mockCheckAuthTokenCookieExist.mockResolvedValue(false);
+            mockCheckAuthTokenCookieExist.mockResolvedValue({ outcome: false });
             
             render(<TaskUser {...defaultProps} userAuthenticated={true} />);
 

--- a/myapps/hello-next-js/src/views/Task/use-client/taskUser.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-client/taskUser.tsx
@@ -18,12 +18,13 @@ const TaskUser = ({userAuthenticated, setUserAuthenticated} : TaskUserType) => {
         const checkUserLoggedIn = async () => {
             // for reference: the http only auth_token cookie is not accessible from the client-side
             const authTokenCookieExist = await checkAuthTokenCookieExist();
-            if (authTokenCookieExist && !userAuthenticated) {
+            if (authTokenCookieExist.outcome && !userAuthenticated) {
                 setUserAuthenticated(true);
             }
-            if (!authTokenCookieExist && userAuthenticated) {
+            if (!authTokenCookieExist.outcome && userAuthenticated) {
+                await logoutUser();
                 setUserAuthenticated(false);
-
+            
                 // TODO: a modal popup that says "you have been logged out"
             }
         };

--- a/myapps/hello-next-js/src/views/Task/use-server/taskDetailPage.test.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskDetailPage.test.tsx
@@ -57,6 +57,7 @@ jest.mock('../../../lib/app/common', () => ({
 }));
 
 import { getRowFromId, deleteRowFromId } from '../../../viewModels/Task/use-server/getTasksViewModel';
+import { checkAuthTokenCookieExist } from '../../../viewModels/Task/use-server/getTasksUserViewModel';
 
 const mockGetRowFromId = getRowFromId as jest.MockedFunction<typeof getRowFromId>;
 const mockDeleteRowFromId = deleteRowFromId as jest.MockedFunction<typeof deleteRowFromId>;
@@ -72,6 +73,7 @@ describe('TaskDetailPage', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: true });
         // Clear console.error mock to reduce noises between tests
         jest.spyOn(console, 'error').mockImplementation(() => {});
     });

--- a/myapps/hello-next-js/src/views/Task/use-server/taskDetailPage.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskDetailPage.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { getRowFromId, deleteRowFromId } from '@/viewModels/Task/use-server/getTasksViewModel';
-import { checkAuthTokenCookieExist } from '@/viewModels/Task/use-server/getTasksUserViewModel';
+import { checkAuthTokenCookieExist, logoutUser } from '@/viewModels/Task/use-server/getTasksUserViewModel';
 import { TaskDetail } from '@/components/Task/use-server/TaskDetail';
 import type { Task } from '@/types/Task';
 import { MONOREPO_PREFIX, TASKS_CRUD } from '@/lib/app/common';
@@ -38,12 +38,13 @@ export const TaskDetailPage = ({id}: {id: number}) => {
           try {
             // for reference: the http only auth_token cookie is not accessible from the client-side
             const authTokenCookieExist = await checkAuthTokenCookieExist();
-            if (authTokenCookieExist && !userAuthenticated) {
+            if (authTokenCookieExist.outcome && !userAuthenticated) {
                 setUserAuthenticated(true);
             }
-            if (!authTokenCookieExist && userAuthenticated) {
+            if (!authTokenCookieExist.outcome && userAuthenticated) {
+                await logoutUser();
                 setUserAuthenticated(false);
-
+                
                 // TODO: a modal popup that says "you have been logged out"
             }
           } catch(err) {

--- a/myapps/hello-next-js/src/views/Task/use-server/taskDetailWithSwrPage.test.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskDetailWithSwrPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { TaskDetailWithSwrPage } from './taskDetailWithSwrPage';
 import { TaskDetailWithSwrType } from '@/components/Task/use-server/TaskDetailWithSwr';
+import { checkAuthTokenCookieExist } from '../../../viewModels/Task/use-server/getTasksUserViewModel';
 import useSWR from 'swr';
 
 let spyConsoleError: jest.SpyInstance<any, any>;
@@ -76,6 +77,8 @@ describe('TaskDetailWithSwrPage', () => {
     beforeEach(() => {
         // hide console.error to reduce noise on the console output
         spyConsoleError = jest.spyOn(console, "error").mockImplementation(()=> {});
+
+        (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: true });
 
         jest.clearAllMocks();
     });

--- a/myapps/hello-next-js/src/views/Task/use-server/taskDetailWithSwrPage.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskDetailWithSwrPage.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import useSWR from 'swr';
 import { fetcher } from '@/viewModels/Task/use-server/getTasksViewModelWithSwr';
 import { deleteRowFromId } from '@/viewModels/Task/use-server/getTasksViewModel';
-import { checkAuthTokenCookieExist } from '@/viewModels/Task/use-server/getTasksUserViewModel';
+import { checkAuthTokenCookieExist, logoutUser } from '@/viewModels/Task/use-server/getTasksUserViewModel';
 import { TaskDetailWithSwr } from '@/components/Task/use-server/TaskDetailWithSwr';
 import type { Task } from '@/types/Task';
 import { MONOREPO_PREFIX, TASKS_CRUD } from '@/lib/app/common';
@@ -46,12 +46,13 @@ export const TaskDetailWithSwrPage = ({id}: {id: number}) => {
       const checkUserLoggedIn = async () => {
           // for reference: the http only auth_token cookie is not accessible from the client-side
           const authTokenCookieExist = await checkAuthTokenCookieExist();
-          if (authTokenCookieExist && !userAuthenticated) {
+          if (authTokenCookieExist.outcome && !userAuthenticated) {
               setUserAuthenticated(true);
           }
-          if (!authTokenCookieExist && userAuthenticated) {
+          if (!authTokenCookieExist.outcome && userAuthenticated) {
+              await logoutUser();
               setUserAuthenticated(false);
-
+              
               // TODO: a modal popup that says "you have been logged out"
           }
       };

--- a/myapps/hello-next-js/src/views/Task/use-server/taskUser.test.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskUser.test.tsx
@@ -6,6 +6,19 @@ jest.mock('../../../viewModels/Task/use-server/getTasksUserViewModel', () => ({
   checkAuthTokenCookieExist: jest.fn(),
 }));
 
+// mock the http only auth_token cookie. 
+// The presence of this cookie indicates that the user has logged in
+jest.mock('next/headers', () => ({
+    cookies: jest.fn(() => ({
+        get: (name: string) => {
+            if (name === 'auth_token') {
+                return { value: 'mocked-token' };
+            }
+            return undefined;
+        },
+    })),
+}));
+
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { TaskUser } from './taskUser';
 import { registerUser, loginUser, logoutUser, checkAuthTokenCookieExist } from '@/viewModels/Task/use-server/getTasksUserViewModel';
@@ -53,7 +66,7 @@ describe('TaskUser Component', () => {
 
     describe('Authentication State Management', () => {
         it('should check auth token on mount and set user as authenticated if token exists', async () => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(true);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({outcome: true});
             
             render(<TaskUser userAuthenticated={false} setUserAuthenticated={mockSetUserAuthenticated} />);
             
@@ -64,7 +77,7 @@ describe('TaskUser Component', () => {
         });
 
         it('should set user as unauthenticated if no auth token exists', async () => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({outcome: false});
             
             render(<TaskUser userAuthenticated={true} setUserAuthenticated={mockSetUserAuthenticated} />);
             
@@ -77,7 +90,7 @@ describe('TaskUser Component', () => {
 
     describe('Unauthenticated User Interface', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({outcome: false});
         });
 
         it('should render login form when user is not authenticated', () => {
@@ -121,7 +134,7 @@ describe('TaskUser Component', () => {
 
     describe('Authenticated User Interface', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(true);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: true});
         });
 
         it('should render logout interface when user is authenticated', async () => {
@@ -138,7 +151,7 @@ describe('TaskUser Component', () => {
 
     describe('Form Validation', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false});
         });
 
         it('should show email validation error for invalid email format', async () => {
@@ -200,7 +213,7 @@ describe('TaskUser Component', () => {
     
     describe('Login Functionality', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false});
         });
 
         it('should successfully login user with valid credentials', async () => {
@@ -259,7 +272,7 @@ describe('TaskUser Component', () => {
 
     describe('Registration Functionality', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false});
         });
 
         it('should successfully register user with valid credentials', async () => {
@@ -305,7 +318,7 @@ describe('TaskUser Component', () => {
     
     describe('Logout Functionality', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(true);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false});
         });
 
 
@@ -339,7 +352,7 @@ describe('TaskUser Component', () => {
     
     describe('Edge Cases and Error Handling', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false });
         });
 
         it('should clear form fields after successful login', async () => {
@@ -362,7 +375,7 @@ describe('TaskUser Component', () => {
         });
 
         it('should clear form fields after successful registration', async () => {
-            (registerUser as jest.Mock).mockResolvedValue(true);
+            (registerUser as jest.Mock).mockResolvedValue({ outcome: true});
             
             render(<TaskUser userAuthenticated={false} setUserAuthenticated={mockSetUserAuthenticated} />);
             

--- a/myapps/hello-next-js/src/views/Task/use-server/taskUser.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskUser.tsx
@@ -16,10 +16,11 @@ export const TaskUser = ({userAuthenticated, setUserAuthenticated} : TaskUserTyp
         const checkUserLoggedIn = async () => {    
             // for reference: the http only auth_token cookie is not accessible from the client-side
             const authTokenCookieExist = await checkAuthTokenCookieExist();
-            if (authTokenCookieExist && !userAuthenticated) {
+            if (authTokenCookieExist.outcome && !userAuthenticated) {
                 setUserAuthenticated(true);
             }
-            if (!authTokenCookieExist && userAuthenticated) {
+            if (!authTokenCookieExist.outcome && userAuthenticated) {
+                await logoutUser();
                 setUserAuthenticated(false);
 
                 // TODO: a modal popup that says "you have been logged out"

--- a/myapps/hello-next-js/src/views/Task/use-server/taskUserGraphQL.test.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskUserGraphQL.test.tsx
@@ -7,6 +7,18 @@ jest.mock('../../../viewModels/Task/use-server/getTasksUserGraphQLViewModel', ()
   registerUser: jest.fn(),
   loginUser: jest.fn(),
 }));
+// mock the http only auth_token cookie. 
+// The presence of this cookie indicates that the user has logged in
+jest.mock('next/headers', () => ({
+    cookies: jest.fn(() => ({
+        get: (name: string) => {
+            if (name === 'auth_token') {
+                return { value: 'mocked-token' };
+            }
+            return undefined;
+        },
+    })),
+}));
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { TaskUserGraphQL } from './taskUserGraphQL';
@@ -56,7 +68,7 @@ describe('TaskUserGraphQL Component', () => {
 
     describe('Authentication State Management', () => {
         it('should check auth token on mount and set user as authenticated if token exists', async () => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(true);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: true});
             
             render(<TaskUserGraphQL userAuthenticated={false} setUserAuthenticated={mockSetUserAuthenticated} />);
             
@@ -67,7 +79,7 @@ describe('TaskUserGraphQL Component', () => {
         });
 
         it('should set user as unauthenticated if no auth token exists', async () => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false});
             
             render(<TaskUserGraphQL userAuthenticated={true} setUserAuthenticated={mockSetUserAuthenticated} />);
             
@@ -80,7 +92,7 @@ describe('TaskUserGraphQL Component', () => {
 
     describe('Unauthenticated User Interface', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false});
         });
 
         it('should render login form when user is not authenticated', () => {
@@ -124,7 +136,7 @@ describe('TaskUserGraphQL Component', () => {
 
     describe('Authenticated User Interface', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(true);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: true});
         });
 
         it('should render logout interface when user is authenticated', () => {
@@ -139,7 +151,7 @@ describe('TaskUserGraphQL Component', () => {
 
     describe('Form Validation', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false});
         });
 
         it('should show email validation error for invalid email format', async () => {
@@ -197,7 +209,7 @@ describe('TaskUserGraphQL Component', () => {
     
     describe('Login Functionality', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false});
         });
 
         it('should successfully login user with valid credentials', async () => {
@@ -256,7 +268,7 @@ describe('TaskUserGraphQL Component', () => {
 
     describe('Registration Functionality', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false});
         });
 
         it('should successfully register user with valid credentials', async () => {
@@ -302,7 +314,7 @@ describe('TaskUserGraphQL Component', () => {
     
     describe('Logout Functionality', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(true);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: true});
         });
 
 
@@ -336,7 +348,7 @@ describe('TaskUserGraphQL Component', () => {
     
     describe('Edge Cases and Error Handling', () => {
         beforeEach(() => {
-            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue(false);
+            (checkAuthTokenCookieExist as jest.Mock).mockResolvedValue({ outcome: false});
         });
 
         it('should clear form fields after successful login', async () => {

--- a/myapps/hello-next-js/src/views/Task/use-server/taskUserGraphQL.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskUserGraphQL.tsx
@@ -17,10 +17,11 @@ export const TaskUserGraphQL = ({userAuthenticated, setUserAuthenticated} : Task
         const checkUserLoggedIn = async () => {
             // for reference: the http only auth_token cookie is not accessible from the client-side
             const authTokenCookieExist = await checkAuthTokenCookieExist();
-            if (authTokenCookieExist && !userAuthenticated) {
+            if (authTokenCookieExist.outcome && !userAuthenticated) {
                 setUserAuthenticated(true);
             }
-            if (!authTokenCookieExist && userAuthenticated) {
+            if (!authTokenCookieExist.outcome && userAuthenticated) {
+                await logoutUser();
                 setUserAuthenticated(false);
 
                 // TODO: a modal popup that says "you have been logged out"


### PR DESCRIPTION
- Delete the http-only cookie if the token has already expired instead of merely invalidating it.
- Unlike the current implementation of which both the "auth_token" cookie, and the JWT stored in DB have got an identical lifespan (1hr), in this implementation, the cookie has got a longer lifespan: 1 hr, whereas the JWT lifespan is set to 15 minutes. Therefore every 15 minutes, users will have re-login in order to continue interacting with the content table on the web app. (JWT is meant to have a very short lifespan for security reason, hence the primary purpose of the refresh_token to bypass the manual login operation)  
- Decided not to implement "refresh token" feature on this manual implementation. Instead, I will go straight to implement the OAUTH 2.0 with Auth0 (basic auth with access token, and refresh token) which mimics the real-world implementation.  
