### PR TITLE
hello-next-js refactor: tidy up TASK CRUD

### DIFF
--- a/myapps/hello-next-js/pages/api/tasks/v1/bff/user/register.ts
+++ b/myapps/hello-next-js/pages/api/tasks/v1/bff/user/register.ts
@@ -9,7 +9,7 @@ import {
     TASKS_API_HEADER, 
 } from "@/lib/app/common";
 import { APP_ENV, LOCALHOST_MODE, LIVE_SITE_MODE } from '@/lib/app/featureFlags';
-import { getJwtSecret } from '@/lib/app/common';
+import { getJwtSecret, generateJWT } from '@/lib/app/common';
 
 const fnSignature = "tasks/v1 | BFF | user/register.ts";
 const customResponseMessage = async (fnName: string, customMsg: string) => {
@@ -74,15 +74,6 @@ export const generateHashedPassword = async (password: string) => {
         timeCost: 5, // number of iterations - higher = slower = safer
         parallelism: 1, // can increase if needed - match your server's CPU capabilities
     });
-}
-
-// TODO: move this to @/lib/app/common
-export const generateJWT = async (email: string, hashedPwd: string, jwtSecret: string) => {
-    return await sign(
-        { email, hashedPassword: hashedPwd  },
-        jwtSecret,
-        { expiresIn: '900000' } // 90000ms = 15mins
-    );
 }
 
 const handler = async (req: NextApiRequest, res: NextApiResponse, overrideFetchUrl?: string): Promise<void> => {

--- a/myapps/hello-next-js/src/lib/app/common.ts
+++ b/myapps/hello-next-js/src/lib/app/common.ts
@@ -104,7 +104,6 @@ export const getJwtSecret = async () => {
     }  
 }
 
-
 export type VerifyJwtResult =
   | { valid: true; payload: string | JwtPayload }
   | { valid: false; error: string };

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserGraphQLViewModel.test.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserGraphQLViewModel.test.ts
@@ -6,13 +6,13 @@ import {
   getJwtSecret,
   createAuthCookie,
   generateHashedPassword,
-  generateJWT
 } from './getTasksUserViewModel';
-
+import { generateJWT } from '@/lib/app/common';
 // Mock all dependencies
 jest.mock('../../../models/Task/use-server/TaskUserGraphqlClient');
 jest.mock('argon2');
 jest.mock('./getTasksUserViewModel');
+jest.mock('../../../lib/app/common');
 
 const mockFetchGraphQL = fetchGraphQL as jest.MockedFunction<typeof fetchGraphQL>;
 const mockArgon2Verify = argon2.verify as jest.MockedFunction<typeof argon2.verify>;

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserGraphQLViewModel.test.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserGraphQLViewModel.test.ts
@@ -3,11 +3,10 @@ import { fetchGraphQL } from '@/models/Task/use-server/TaskUserGraphqlClient';
 import argon2 from 'argon2';
 import {
   logoutUser,
-  getJwtSecret,
   createAuthCookie,
   generateHashedPassword,
 } from './getTasksUserViewModel';
-import { generateJWT } from '@/lib/app/common';
+import { generateJWT, getJwtSecret } from '@/lib/app/common';
 // Mock all dependencies
 jest.mock('../../../models/Task/use-server/TaskUserGraphqlClient');
 jest.mock('argon2');
@@ -17,10 +16,11 @@ jest.mock('../../../lib/app/common');
 const mockFetchGraphQL = fetchGraphQL as jest.MockedFunction<typeof fetchGraphQL>;
 const mockArgon2Verify = argon2.verify as jest.MockedFunction<typeof argon2.verify>;
 const mockLogoutUser = logoutUser as jest.MockedFunction<typeof logoutUser>;
-const mockGetJwtSecret = getJwtSecret as jest.MockedFunction<typeof getJwtSecret>;
 const mockCreateAuthCookie = createAuthCookie as jest.MockedFunction<typeof createAuthCookie>;
 const mockGenerateHashedPassword = generateHashedPassword as jest.MockedFunction<typeof generateHashedPassword>;
+
 const mockGenerateJWT = generateJWT as jest.MockedFunction<typeof generateJWT>;
+const mockGetJwtSecret = getJwtSecret as jest.MockedFunction<typeof getJwtSecret>;
 
 describe('GetTasksUserGraphQLViewModel', () => {
   beforeEach(() => {

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserGraphQLViewModel.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserGraphQLViewModel.ts
@@ -4,11 +4,10 @@ import { fetchGraphQL } from '@/models/Task/use-server/TaskUserGraphqlClient';
 import argon2 from 'argon2';
 import { 
     logoutUser, 
-    getJwtSecret, 
     createAuthCookie, 
     generateHashedPassword,  
 } from './getTasksUserViewModel';
-import { generateJWT } from '@/lib/app/common';
+import { generateJWT, getJwtSecret } from '@/lib/app/common';
 
 import type { UserModelType } from '@/types/Task';
 

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserGraphQLViewModel.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserGraphQLViewModel.ts
@@ -6,9 +6,10 @@ import {
     logoutUser, 
     getJwtSecret, 
     createAuthCookie, 
-    generateHashedPassword, 
-    generateJWT 
+    generateHashedPassword,  
 } from './getTasksUserViewModel';
+import { generateJWT } from '@/lib/app/common';
+
 import type { UserModelType } from '@/types/Task';
 
 const fnSignature = "use-server | view-model | getTasksUserGraphQLViewModel";

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.test.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.test.ts
@@ -2,7 +2,6 @@ import {
   getJwtSecret,
   createAuthCookie,
   generateHashedPassword,
-  generateJWT,
   registerUser,
   loginUser,
   logoutUser,
@@ -52,6 +51,7 @@ jest.mock('../../../lib/app/featureFlags', () => ({
 jest.mock('../../../lib/app/common', () => ({
   JWT_TOKEN_COOKIE_NAME: 'auth_token',
   TASKS_SQL_BASE_API_URL: 'http://test-api.com',
+  generateJWT: jest.fn().mockResolvedValue("new.jwt.token"),
   VERIFY_JWT_STRING: jest.fn().mockResolvedValue({ valid: true, payload: "" }),
 }));
 
@@ -60,7 +60,7 @@ import { getSecret } from '@/lib/app/awsSecretManager';
 import argon2 from 'argon2';
 import { sign } from 'jsonwebtoken';
 import { registerUser as registerUserModel, logInUser as logInUserModel } from '@/models/Task/use-server/TaskUserModel';
-import { VERIFY_JWT_STRING } from '@/lib/app/common';
+import { generateJWT, VERIFY_JWT_STRING } from '@/lib/app/common';
 
 describe("getTasksUserViewModel", () => {
     interface MockCookieStore {
@@ -222,26 +222,6 @@ describe("getTasksUserViewModel", () => {
             parallelism: 1
         });
         expect(result).toBe(hashedPassword);
-        });
-    });
-
-    describe('generateJWT', () => {
-        it('should generate JWT token successfully', async () => {
-        const email = 'test@example.com';
-        const hashedPwd = 'hashed_password';
-        const jwtSecret = 'secret_key';
-        const expectedToken = 'jwt.token.here';
-        
-        (sign as jest.Mock).mockResolvedValue(expectedToken);
-
-        const result = await generateJWT(email, hashedPwd, jwtSecret);
-
-        expect(sign).toHaveBeenCalledWith(
-            { email, hashedPassword: hashedPwd },
-            jwtSecret,
-            { expiresIn: '900000' } // 90000sec = 15mins
-        );
-        expect(result).toBe(expectedToken);
         });
     });
 

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.test.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.test.ts
@@ -1,5 +1,4 @@
 import {
-  getJwtSecret,
   createAuthCookie,
   generateHashedPassword,
   registerUser,
@@ -7,6 +6,8 @@ import {
   logoutUser,
   checkAuthTokenCookieExist
 } from './getTasksUserViewModel';
+
+import { getJwtSecret } from '@/lib/app/common';
 
 // Mock external dependencies
 jest.mock('next/headers', () => ({
@@ -49,10 +50,11 @@ jest.mock('../../../lib/app/featureFlags', () => ({
 }));
 
 jest.mock('../../../lib/app/common', () => ({
-  JWT_TOKEN_COOKIE_NAME: 'auth_token',
-  TASKS_SQL_BASE_API_URL: 'http://test-api.com',
-  generateJWT: jest.fn().mockResolvedValue("new.jwt.token"),
-  VERIFY_JWT_STRING: jest.fn().mockResolvedValue({ valid: true, payload: "" }),
+    JWT_TOKEN_COOKIE_NAME: 'auth_token',
+    TASKS_SQL_BASE_API_URL: 'http://test-api.com',
+    generateJWT: jest.fn().mockResolvedValue("new.jwt.token"),
+    VERIFY_JWT_STRING: jest.fn().mockResolvedValue({ valid: true, payload: "" }),
+    getJwtSecret: jest.fn().mockResolvedValue({ jwtSecret: "123" }),
 }));
 
 import { cookies } from 'next/headers';
@@ -123,34 +125,6 @@ describe("getTasksUserViewModel", () => {
 
     afterAll(() => {
         jest.restoreAllMocks();
-    });
-
-    describe('getJwtSecret', () => {
-        it('should successfully retrieve JWT secret from AWS Secret Manager', async () => {
-            const mockSecret = { jwtSecret: 'test-secret-123' };
-            (getSecret as jest.Mock).mockResolvedValue(mockSecret);
-
-            const result = await getJwtSecret();
-
-            expect(getSecret).toHaveBeenCalledWith(
-                'dev/hello-next-js/jwt-secret',
-                'us-east-1'
-            );
-            expect(result).toEqual(mockSecret);
-        });
-
-        it('should throw error when AWS_REGION is missing', async () => {
-            delete process.env.AWS_REGION;
-
-            await expect(getJwtSecret()).rejects.toThrow('AWS Region is missing');
-        });
-
-        it('should handle AWS Secret Manager errors', async () => {
-            const error = new Error('AWS Secret Manager error');
-            (getSecret as jest.Mock).mockRejectedValue(error);
-
-            await expect(getJwtSecret()).rejects.toThrow('AWS Secret Manager error');
-        });
     });
 
     describe('createAuthCookie', () => {

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import { cookies } from 'next/headers';
-import { getSecret } from '@/lib/app/awsSecretManager';
 import argon2 from 'argon2';
 import { 
     JWT_TOKEN_COOKIE_NAME, 
@@ -9,6 +8,7 @@ import {
     VERIFY_JWT_STRING,
     verifyJwtErrorMsgs,
     generateJWT,
+    getJwtSecret,
 } from '@/lib/app/common';
 import { 
     registerUser as registerUserModel, 
@@ -27,26 +27,6 @@ const catchedErrorMessage = async (fnName: string, error: Error) => {
     const errorMsg = `${fnSignature} | ${fnName} | catched error: ${error.name} - ${error.message}`;
     console.error(errorMsg);
     return errorMsg;
-}
-
-// TODO: Move this to @/lib/app/common
-export const getJwtSecret = async () => {
-    try {
-        if (!process.env.AWS_REGION) {
-            throw new Error("AWS Region is missing");
-        }
-
-        // obtain jwt secret from the AWS secret manager
-        const secret: { jwtSecret: string } = await getSecret(
-            "dev/hello-next-js/jwt-secret", // or prod/hello-next-js/jwt-secret for prod ENV
-            process.env.AWS_REGION
-        );
-
-        return secret;
-    } catch(err) {
-        const errorMsg = await catchedErrorMessage("getJwtSecret", err as Error);
-        throw new Error(errorMsg);
-    }  
 }
 
 export const createAuthCookie = async (jwt: string) => {

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
@@ -3,12 +3,12 @@
 import { cookies } from 'next/headers';
 import { getSecret } from '@/lib/app/awsSecretManager';
 import argon2 from 'argon2';
-import { sign } from 'jsonwebtoken';
 import { 
     JWT_TOKEN_COOKIE_NAME, 
     TASKS_SQL_BASE_API_URL,  
     VERIFY_JWT_STRING,
     verifyJwtErrorMsgs,
+    generateJWT,
 } from '@/lib/app/common';
 import { 
     registerUser as registerUserModel, 
@@ -27,15 +27,6 @@ const catchedErrorMessage = async (fnName: string, error: Error) => {
     const errorMsg = `${fnSignature} | ${fnName} | catched error: ${error.name} - ${error.message}`;
     console.error(errorMsg);
     return errorMsg;
-}
-
-// TODO: Move this to @/lib/app/common
-export const generateJWT = async (email: string, hashedPwd: string, jwtSecret: string) => {
-    return await sign(
-        { email, hashedPassword: hashedPwd  },
-        jwtSecret,
-        { expiresIn: '900000' } // 90000ms = 15mins
-    );
 }
 
 // TODO: Move this to @/lib/app/common

--- a/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
+++ b/myapps/hello-next-js/src/viewModels/Task/use-server/getTasksUserViewModel.ts
@@ -30,6 +30,15 @@ const catchedErrorMessage = async (fnName: string, error: Error) => {
 }
 
 // TODO: Move this to @/lib/app/common
+export const generateJWT = async (email: string, hashedPwd: string, jwtSecret: string) => {
+    return await sign(
+        { email, hashedPassword: hashedPwd  },
+        jwtSecret,
+        { expiresIn: '900000' } // 90000ms = 15mins
+    );
+}
+
+// TODO: Move this to @/lib/app/common
 export const getJwtSecret = async () => {
     try {
         if (!process.env.AWS_REGION) {
@@ -85,14 +94,6 @@ export const generateHashedPassword = async (password: string) => {
         timeCost: 5, // number of iterations - higher = slower = safer
         parallelism: 1, // can increase if needed - match your server's CPU capabilities
     });
-}
-
-export const generateJWT = async (email: string, hashedPwd: string, jwtSecret: string) => {
-    return await sign(
-        { email, hashedPassword: hashedPwd  },
-        jwtSecret,
-        { expiresIn: '900000' } // 90000ms = 15mins
-    );
 }
 
 export const registerUser = async (email: string, password: string) => {

--- a/myapps/hello-next-js/src/views/Task/use-client/taskDetailPage.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-client/taskDetailPage.tsx
@@ -33,7 +33,6 @@ export const TaskDetailPage = ({id}: {id: number}) => {
                   setUserAuthenticated(true);
               }
               if (!authTokenCookieExist.outcome && userAuthenticated) {
-                  await logoutUser();
                   setUserAuthenticated(false);
                   
                   // TODO: a modal popup that says "you have been logged out"

--- a/myapps/hello-next-js/src/views/Task/use-client/taskDetailPage.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-client/taskDetailPage.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 import Link from 'next/link';
 //import { useTaskViewModel } from '@/app/viewModels/Task/use-client/useTasksViewModel';
 import { useTaskViewModelWithSwr } from '@/viewModels/Task/use-client/useTasksViewModelWithSwr';
@@ -24,7 +24,7 @@ export const TaskDetailPage = ({id}: {id: number}) => {
     }     
   }, [id, tasks]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
         const checkUserLoggedIn = async () => {
             // for reference: the http only auth_token cookie is not accessible from the client-side
             try {

--- a/myapps/hello-next-js/src/views/Task/use-client/taskUser.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-client/taskUser.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, MouseEvent, memo } from "react";
+import { useLayoutEffect, useState, MouseEvent, memo } from "react";
 import styles from "@/app/page.module.css";
 import useTaskUserViewModel from "@/viewModels/Task/use-client/useTaskUserViewModel";
 import type { TaskUserType } from "@/types/Task";
@@ -14,7 +14,7 @@ const TaskUser = ({userAuthenticated, setUserAuthenticated} : TaskUserType) => {
 
     const { loading, registerUser, loginUser, logoutUser, checkAuthTokenCookieExist } = useTaskUserViewModel();
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         const checkUserLoggedIn = async () => {
             // for reference: the http only auth_token cookie is not accessible from the client-side
             const authTokenCookieExist = await checkAuthTokenCookieExist();
@@ -22,7 +22,6 @@ const TaskUser = ({userAuthenticated, setUserAuthenticated} : TaskUserType) => {
                 setUserAuthenticated(true);
             }
             if (!authTokenCookieExist.outcome && userAuthenticated) {
-                await logoutUser();
                 setUserAuthenticated(false);
             
                 // TODO: a modal popup that says "you have been logged out"

--- a/myapps/hello-next-js/src/views/Task/use-server/taskDetailPage.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskDetailPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 // for reference: don't let the folder name mislead you, a view component cannot be a server component.
 // the uniform folder name is for the sake of consistency
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 import Link from 'next/link';
 import { getRowFromId, deleteRowFromId } from '@/viewModels/Task/use-server/getTasksViewModel';
 import { checkAuthTokenCookieExist, logoutUser } from '@/viewModels/Task/use-server/getTasksUserViewModel';
@@ -33,7 +33,7 @@ export const TaskDetailPage = ({id}: {id: number}) => {
     fetchTask();
   }, []); // run once only
 
-  useEffect(() => {
+  useLayoutEffect(() => {
       const checkUserLoggedIn = async () => {
           try {
             // for reference: the http only auth_token cookie is not accessible from the client-side

--- a/myapps/hello-next-js/src/views/Task/use-server/taskDetailPage.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskDetailPage.tsx
@@ -42,7 +42,6 @@ export const TaskDetailPage = ({id}: {id: number}) => {
                 setUserAuthenticated(true);
             }
             if (!authTokenCookieExist.outcome && userAuthenticated) {
-                await logoutUser();
                 setUserAuthenticated(false);
                 
                 // TODO: a modal popup that says "you have been logged out"

--- a/myapps/hello-next-js/src/views/Task/use-server/taskDetailWithSwrPage.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskDetailWithSwrPage.tsx
@@ -50,7 +50,6 @@ export const TaskDetailWithSwrPage = ({id}: {id: number}) => {
               setUserAuthenticated(true);
           }
           if (!authTokenCookieExist.outcome && userAuthenticated) {
-              await logoutUser();
               setUserAuthenticated(false);
               
               // TODO: a modal popup that says "you have been logged out"

--- a/myapps/hello-next-js/src/views/Task/use-server/taskDetailWithSwrPage.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskDetailWithSwrPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 // for reference: don't let the folder name mislead you, a view component cannot be a server component.
 // the uniform folder name is for the sake of consistency
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 import Link from 'next/link';
 import useSWR from 'swr';
 import { fetcher } from '@/viewModels/Task/use-server/getTasksViewModelWithSwr';
@@ -42,7 +42,7 @@ export const TaskDetailWithSwrPage = ({id}: {id: number}) => {
     }
   }, []); // run once only
 
-  useEffect(() => {
+  useLayoutEffect(() => {
       const checkUserLoggedIn = async () => {
           // for reference: the http only auth_token cookie is not accessible from the client-side
           const authTokenCookieExist = await checkAuthTokenCookieExist();

--- a/myapps/hello-next-js/src/views/Task/use-server/taskUser.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskUser.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, MouseEvent } from "react";
+import { useLayoutEffect, useState, MouseEvent } from "react";
 import styles from "@/app/page.module.css";
 import { registerUser, loginUser, logoutUser, checkAuthTokenCookieExist } from "@/viewModels/Task/use-server/getTasksUserViewModel";
 import { TaskUserType } from "@/types/Task";
@@ -12,7 +12,7 @@ export const TaskUser = ({userAuthenticated, setUserAuthenticated} : TaskUserTyp
     const [passwordMessage, setPasswordMessage] = useState<string>("");
     const [formMessage, setFormMessage] = useState<string>("only logged-in users can interact with the table");
     
-    useEffect(() => {
+    useLayoutEffect(() => {
         const checkUserLoggedIn = async () => {    
             // for reference: the http only auth_token cookie is not accessible from the client-side
             const authTokenCookieExist = await checkAuthTokenCookieExist();
@@ -20,7 +20,6 @@ export const TaskUser = ({userAuthenticated, setUserAuthenticated} : TaskUserTyp
                 setUserAuthenticated(true);
             }
             if (!authTokenCookieExist.outcome && userAuthenticated) {
-                await logoutUser();
                 setUserAuthenticated(false);
 
                 // TODO: a modal popup that says "you have been logged out"

--- a/myapps/hello-next-js/src/views/Task/use-server/taskUserGraphQL.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskUserGraphQL.tsx
@@ -21,7 +21,6 @@ export const TaskUserGraphQL = ({userAuthenticated, setUserAuthenticated} : Task
                 setUserAuthenticated(true);
             }
             if (!authTokenCookieExist.outcome && userAuthenticated) {
-                await logoutUser();
                 setUserAuthenticated(false);
 
                 // TODO: a modal popup that says "you have been logged out"

--- a/myapps/hello-next-js/src/views/Task/use-server/taskUserGraphQL.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskUserGraphQL.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, MouseEvent } from "react";
+import { useEffect, useLayoutEffect, useState, MouseEvent } from "react";
 import styles from "@/app/page.module.css";
 import { logoutUser, checkAuthTokenCookieExist } from "@/viewModels/Task/use-server/getTasksUserViewModel";
 import { registerUser, loginUser } from "@/viewModels/Task/use-server/getTasksUserGraphQLViewModel";
@@ -13,7 +13,7 @@ export const TaskUserGraphQL = ({userAuthenticated, setUserAuthenticated} : Task
     const [passwordMessage, setPasswordMessage] = useState<string>("");
     const [formMessage, setFormMessage] = useState<string>("only logged-in users can interact with the table");
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         const checkUserLoggedIn = async () => {
             // for reference: the http only auth_token cookie is not accessible from the client-side
             const authTokenCookieExist = await checkAuthTokenCookieExist();


### PR DESCRIPTION
- make generateJWT, & getJwtSecret fn reusable
- check user login status is called within useLayoutEffect, instead of useEffect