### PR TITLE
hello-next-js: feat: TASK CRUD - locally stored secret key for localhost test

### DIFF
--- a/dockerfile_hellonextjs_standalone_mode
+++ b/dockerfile_hellonextjs_standalone_mode
@@ -70,6 +70,10 @@ USER node
 #ENV NEXT_TELEMETRY_DISABLED=1
 #ENV NODE_ENV=production
 
+# except this one
+ENV APP_ENV=LIVE
+ENV SECRETLOCATION=REMOTE
+
 # Expose the default next.js port
 EXPOSE 3000
 

--- a/myapps/hello-next-js/README.md
+++ b/myapps/hello-next-js/README.md
@@ -239,13 +239,30 @@ For more info, have a look at [sql_create_tables.sql](https://github.com/hey-you
 docker start hellonextjs-postgresdb
 ```
 
-6. run the dev build of hello-next-js
+6. Add the following environment variables in .env.local:
+```bash
+APP_ENV=LOCAL
+SECRETLOCATION=LOCAL
+TEST_JWT_SECRET=12345
+TEST_API_KEY=67890
+```
+
+7. run the dev build of hello-next-js
 ```bash
 yarn workspace hello-next-js dev
 ```
+or 
+run the optimised build for prod of hello-next-js (recommended approach)
+```bash
+yarn workspace hello-next-js build
+```
+then
+```bash
+yarn workspace hello-next-js start
+```
+ 
+8. The URL (Client components MVVM): [localhost:3000/hello-next-js/task-crud-fullstack](http://localhost:3000/hello-next-js/task-crud-fullstack)
 
-7. The URL (Client components MVVM): [localhost:3000/hello-next-js/task-crud-fullstack](http://localhost:3000/hello-next-js/task-crud-fullstack)
+9. The URL (Server components MVVM): [localhost:3000/hello-next-js/task-crud-fullstack/use-server](http://localhost:3000/hello-next-js/task-crud-fullstack/use-server)
 
-8. The URL (Server components MVVM): [localhost:3000/hello-next-js/task-crud-fullstack/use-server](http://localhost:3000/hello-next-js/task-crud-fullstack/use-server)
-
-9. For the rest of demo pages: [localhost demo](https://github.com/hey-you-d/mymonorepo/blob/master/myapps/hello-next-js/README.md#localhost-demo)
+10. For the rest of demo pages: [localhost demo](https://github.com/hey-you-d/mymonorepo/blob/master/myapps/hello-next-js/README.md#localhost-demo)

--- a/myapps/hello-next-js/__tests__/api/tasks/v1/bff/user/httpcookie.test.ts
+++ b/myapps/hello-next-js/__tests__/api/tasks/v1/bff/user/httpcookie.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../../../../../src/lib/app/common', () => ({
 }));
 
 jest.mock('../../../../../../src/lib/app/featureFlags', () => ({
-  APP_ENV: 'LOCALHOST',
+  APP_ENV: 'LOCAL',
   LIVE_SITE_MODE: {
     cookie: {
       path: '/',
@@ -30,7 +30,6 @@ jest.mock('../../../../../../src/lib/app/featureFlags', () => ({
 
 // Import mocked functions
 import { VERIFY_JWT_STRING, verifyJwtErrorMsgs } from '@/lib/app/common';
-import { APP_ENV, LIVE_SITE_MODE, LOCALHOST_MODE } from '@/lib/app/featureFlags';
 
 const mockVerifyJwtString = VERIFY_JWT_STRING as jest.MockedFunction<typeof VERIFY_JWT_STRING>;
 

--- a/myapps/hello-next-js/__tests__/api/tasks/v1/bff/user/register.test.ts
+++ b/myapps/hello-next-js/__tests__/api/tasks/v1/bff/user/register.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../../../../../src/lib/app/common', () => ({
 }));
 
 jest.mock('../../../../../../src/lib/app/featureFlags', () => ({
-  APP_ENV: 'TEST',
+  APP_ENV: 'LOCAL',
   LIVE_SITE_MODE: {
     cookie: {
       path: '/live',

--- a/myapps/hello-next-js/src/lib/app/common.ts
+++ b/myapps/hello-next-js/src/lib/app/common.ts
@@ -3,7 +3,7 @@ import type { Request as ExpressRequest } from 'express';
 import type { VerifyJwtResult } from '@/types/Task';
 import { getSecret } from "./awsParameterStore";
 import { getSecret as getFrmSecretMgr } from '@/lib/app/awsSecretManager';
-import { LOCALHOST_MODE, LIVE_SITE_MODE, APP_ENV } from './featureFlags';
+import { LOCALHOST_MODE, LIVE_SITE_MODE, APP_ENV, SECRET_LOCATION } from './featureFlags';
 import * as cookie from 'cookie';
 import { verify, sign } from 'jsonwebtoken';
 
@@ -78,6 +78,10 @@ export const TASKS_API_HEADER = async (jwt?: string) => {
 
 // for reference: can only be called on server-side only
 export const CHECK_API_KEY = async (req: NextApiRequest, _: NextApiResponse) => {
+    if (SECRET_LOCATION === "LOCAL") {
+        return process.env.TEST_API_KEY ? process.env.TEST_API_KEY : "67890";
+    }
+
     const clientKey = req.headers["x-api-key"];
     const serverKey = await getInternalApiKey();
 
@@ -93,6 +97,10 @@ export const generateJWT = async (email: string, hashedPwd: string, jwtSecret: s
 }
 
 export const getJwtSecret = async () => {
+    if (SECRET_LOCATION === "LOCAL") {
+        return { jwtSecret: process.env.TEST_JWT_SECRET ? process.env.TEST_JWT_SECRET : "12345" };
+    }
+
     try {
         if (!process.env.AWS_REGION) {
             throw new Error("AWS Region is missing");

--- a/myapps/hello-next-js/src/lib/app/featureFlags.ts
+++ b/myapps/hello-next-js/src/lib/app/featureFlags.ts
@@ -1,3 +1,8 @@
+// REMOTE: JWT secret is stored in AWS Secret Manager, API key is stored in AWS Parameter Store
+// LOCAL: both secrets are defined in env.local
+type SecretLocationType = "REMOTE" | "LOCAL";
+// LIVE: remote (serverless) hosting
+// LOCAL: localhost
 type AppEnvType = "LIVE" | "LOCAL";
 type EnvModeType = {
     apiKeyId: string,
@@ -16,7 +21,15 @@ type EnvModeType = {
     }
 }
 
-export const APP_ENV: AppEnvType = "LOCAL"; // Temporary flag until the prod db is ready
+// server-side only. 
+export const APP_ENV: AppEnvType = process.env.APP_ENV // process.env.APP_ENV is defined in both .env.local & dockerfile 
+    ? process.env.APP_ENV as AppEnvType
+    : "LOCAL";
+
+// server-side only - SECRET_LOCATION is always set to REMOTE if APP_ENV === LIVE
+export const SECRET_LOCATION: SecretLocationType = process.env.SECRETLOCATION
+    ? APP_ENV === "LOCAL" ? process.env.SECRETLOCATION as SecretLocationType : "REMOTE"
+    : "LOCAL";
 
 export const LIVE_SITE_MODE: EnvModeType = {
     apiKeyId: "/prod/tasks/bff/x-api-key",

--- a/myapps/hello-next-js/src/views/Task/use-server/taskGraphQLPage.test.tsx
+++ b/myapps/hello-next-js/src/views/Task/use-server/taskGraphQLPage.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Task } from "@/types/Task";
+import { LOCALHOST_MODE, SECRET_LOCATION } from "../../../lib/app/featureFlags";
 
 // mock the http only auth_token cookie. 
 // The presence of this cookie indicates that the user has logged in
@@ -14,6 +15,23 @@ jest.mock('next/headers', () => ({
             return undefined;
         },
     })),
+}));
+
+jest.mock("../../../lib/app/featureFlags", () => ({
+    APP_ENV: "LOCAL",
+    SECRET_LOCATION: "REMOTE",
+    LOCALHOST_MODE: {
+        apiKeyId: "/dev/tasks/bff/x-api-key",
+        domain: "http://localhost:3000",
+        base: {
+            clientSide: "", // can be a relative url
+            serverSide: "http://localhost:3000", // must be an absolute url
+        },
+        cookie: {
+            secure: false,
+            path: "/",
+        },
+    }
 }));
 
 // Mock the child components


### PR DESCRIPTION
- For localhost build only without access to the remote storage for secret keys (AWS Secret Manager / AWS Param store)
- For local demo purpose 
- Add the following env variables in .env.local:

APP_ENV=LOCAL
SECRETLOCATION=LOCAL
TEST_JWT_SECRET=12345
TEST_API_KEY=67890